### PR TITLE
Fix type in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ensembling. <br clear="both">
 
 - The directory `data` is for the CorefUD 1.1 data, and the preprocessed
   and tokenized version needed for training.
-  - The script `data/get.sh` downloads and extracts the CorefUD 1.2 training and
+  - The script `data/get.sh` downloads and extracts the CorefUD 1.1 training and
     development data, plus the unannotated test data of the CRAC 2023 shared
     task.
 


### PR DESCRIPTION
The README mentions CorefUD 1.2 which I believe is a typo and should be CorefUD 1.1